### PR TITLE
Include pui issues on Geckoboard and only send prod issues

### DIFF
--- a/sentry_to_geckoboard.rb
+++ b/sentry_to_geckoboard.rb
@@ -4,18 +4,28 @@ require 'faraday'
 api_key = ENV['GECKOBOARD_API_KEY']
 sentry_api_key = ENV['SENTRY_API_KEY']
 
-url = 'https://sentry.service.dsd.io/api/0/projects/mojds/ProviderDeets/issues/'
-resp = Faraday.get(url, {statsPeriod: '24h'}, {'Authorization' => "Bearer #{sentry_api_key}"})
-hits = resp.headers['X-Hits'].to_i
+pda_url = 'https://sentry.service.dsd.io/api/0/projects/mojds/ProviderDeets/issues/'
+pda_resp = Faraday.get(pda_url, {statsPeriod: '24h'}, {'Authorization' => "Bearer #{sentry_api_key}"})
+pda_hits = pda_resp.headers['X-Hits'].to_i
+
+pui_url = 'https://sentry.service.dsd.io/api/0/projects/mojds/pui/issues/'
+pui_resp = Faraday.get(pui_url, {statsPeriod: '24h'}, {'Authorization' => "Bearer #{sentry_api_key}"})
+pui_hits = pui_resp.headers['X-Hits'].to_i
 
 client = Geckoboard.client(api_key)
 
-dataset = client.datasets.find_or_create('ccms.issues', fields: [
+dataset = client.datasets.find_or_create('ccms.sentry.issues', fields: [
+  Geckoboard::StringField.new(:project_name, name: 'Project'),
   Geckoboard::NumberField.new(:number_of_issues, name: 'Number of Issues', optional: false),
 ])
 
 dataset.put([
   {
-    number_of_issues: hits,
+    project_name: 'Provider Details API',
+    number_of_issues: pda_hits,
+  },
+  {
+    project_name: 'PUI',
+    number_of_issues: pui_hits,
   }
 ])

--- a/sentry_to_geckoboard.rb
+++ b/sentry_to_geckoboard.rb
@@ -5,11 +5,11 @@ api_key = ENV['GECKOBOARD_API_KEY']
 sentry_api_key = ENV['SENTRY_API_KEY']
 
 pda_url = 'https://sentry.service.dsd.io/api/0/projects/mojds/ProviderDeets/issues/'
-pda_resp = Faraday.get(pda_url, {statsPeriod: '24h'}, {'Authorization' => "Bearer #{sentry_api_key}"})
+pda_resp = Faraday.get(pda_url, {statsPeriod: '24h', query: 'environment:production'}, {'Authorization' => "Bearer #{sentry_api_key}"})
 pda_hits = pda_resp.headers['X-Hits'].to_i
 
 pui_url = 'https://sentry.service.dsd.io/api/0/projects/mojds/pui/issues/'
-pui_resp = Faraday.get(pui_url, {statsPeriod: '24h'}, {'Authorization' => "Bearer #{sentry_api_key}"})
+pui_resp = Faraday.get(pui_url, {statsPeriod: '24h', query: 'environment:production'}, {'Authorization' => "Bearer #{sentry_api_key}"})
 pui_hits = pui_resp.headers['X-Hits'].to_i
 
 client = Geckoboard.client(api_key)


### PR DESCRIPTION
**What**
- Include number of PUI issues when sending the data to Geckoboard
- Only include issues on production for both PUI and Provider Details API

This is what it will look like on our dashboard:
<img width="549" alt="Screen Shot 2020-01-28 at 13 16 04" src="https://user-images.githubusercontent.com/13121570/73267382-dcb3df00-41d0-11ea-8eef-a040a57858e8.png">


**Why**
- So we can see the stats we want on our dashboard