### PR TITLE
Send number of Connector entries in Sentry to our Geckoboard

### DIFF
--- a/sentry_to_geckoboard.rb
+++ b/sentry_to_geckoboard.rb
@@ -12,6 +12,10 @@ pui_url = 'https://sentry.service.dsd.io/api/0/projects/mojds/pui/issues/'
 pui_resp = Faraday.get(pui_url, {statsPeriod: '24h', query: 'environment:production'}, {'Authorization' => "Bearer #{sentry_api_key}"})
 pui_hits = pui_resp.headers['X-Hits'].to_i
 
+connector_url = 'https://sentry.service.dsd.io/api/0/projects/mojds/connector/issues/'
+connector_resp = Faraday.get(connector_url, {statsPeriod: '24h', query: 'environment:production'}, {'Authorization' => "Bearer #{sentry_api_key}"})
+connector_hits = connector_resp.headers['X-Hits'].to_i
+
 client = Geckoboard.client(api_key)
 
 dataset = client.datasets.find_or_create('ccms.sentry.issues', fields: [
@@ -27,5 +31,9 @@ dataset.put([
   {
     project_name: 'PUI',
     number_of_issues: pui_hits,
-  }
+  },
+  {
+      project_name: 'Connector',
+      number_of_issues: connector_hits,
+    }
 ])


### PR DESCRIPTION
We want to see the number of Sentry errors from the connector on our Geckoboard so that they're visible to everyone.